### PR TITLE
Upgrade Ant to resolve vulnerabilities

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -137,6 +137,30 @@
           <artifactId>build-helper-maven-plugin</artifactId>
           <version>${build-helper-plugin.version}</version>
         </plugin>
+        <plugin>
+          <groupId>org.eclipse.m2e</groupId>
+          <artifactId>lifecycle-mapping</artifactId>
+          <version>1.0.0</version>
+          <configuration>
+            <lifecycleMappingMetadata>
+              <pluginExecutions>
+                <pluginExecution>
+                  <pluginExecutionFilter>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-dependency-plugin</artifactId>
+                    <versionRange>[1.0.0,)</versionRange>
+                    <goals>
+                      <goal>properties</goal>
+                    </goals>
+                  </pluginExecutionFilter>
+                  <action>
+                    <execute />
+                  </action>
+                </pluginExecution>
+              </pluginExecutions>
+            </lifecycleMappingMetadata>
+          </configuration>
+        </plugin>
       </plugins>
     </pluginManagement>
 
@@ -298,6 +322,7 @@
       <properties>
         <maven.compiler.release>8</maven.compiler.release>
         <testng.version>7.3.0</testng.version>
+        <ant.version>1.10.11</ant.version>
       </properties>
       <dependencyManagement>
         <dependencies>
@@ -305,6 +330,11 @@
             <groupId>org.testng</groupId>
             <artifactId>testng</artifactId>
             <version>${testng.version}</version>
+          </dependency>
+          <dependency>
+            <groupId>org.apache.ant</groupId>
+            <artifactId>ant</artifactId>
+            <version>${ant.version}</version>
           </dependency>
         </dependencies>
       </dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -137,30 +137,6 @@
           <artifactId>build-helper-maven-plugin</artifactId>
           <version>${build-helper-plugin.version}</version>
         </plugin>
-        <plugin>
-          <groupId>org.eclipse.m2e</groupId>
-          <artifactId>lifecycle-mapping</artifactId>
-          <version>1.0.0</version>
-          <configuration>
-            <lifecycleMappingMetadata>
-              <pluginExecutions>
-                <pluginExecution>
-                  <pluginExecutionFilter>
-                    <groupId>org.apache.maven.plugins</groupId>
-                    <artifactId>maven-dependency-plugin</artifactId>
-                    <versionRange>[1.0.0,)</versionRange>
-                    <goals>
-                      <goal>properties</goal>
-                    </goals>
-                  </pluginExecutionFilter>
-                  <action>
-                    <execute />
-                  </action>
-                </pluginExecution>
-              </pluginExecutions>
-            </lifecycleMappingMetadata>
-          </configuration>
-        </plugin>
       </plugins>
     </pluginManagement>
 


### PR DESCRIPTION
Upgrading the version of Ant brought in by TestNG 7.3.0 from 1.10.3 to 1.10.11. This upgrade resolves several vulnerabilities:

* [CVE-2021-36373](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-36373) - Low: Denial of Service 
* [CVE-2021-36374](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-36374) - Low: Denial of Service
* [CVE-2020-11979](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-11979) - Medium: insecure temporary file vulnerability
* [CVE-2020-1945](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-1945) - Medium: insecure temporary file vulnerability